### PR TITLE
fix: add container resource requests so HPA can compute CPU utilization

### DIFF
--- a/hello-world/Chart.yaml
+++ b/hello-world/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: hello-world
 description: A Hello World Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.16.0"

--- a/hello-world/templates/deployment.yaml
+++ b/hello-world/templates/deployment.yaml
@@ -48,6 +48,10 @@ spec:
               port: http
             initialDelaySeconds: 2
             periodSeconds: 5
+{{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+{{- end }}
 {{- if .Values.cloudflared.enabled }}
         # Cloudflared sidecar - only included if cloudflared.enabled=true
         - name: cloudflared
@@ -67,6 +71,10 @@ spec:
           volumeMounts:
             - name: cloudflared-creds
               mountPath: /etc/cloudflared
+{{- with .Values.cloudflared.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+{{- end }}
 {{- end }}
       volumes:
 {{- if .Values.cloudflared.enabled }}

--- a/hello-world/templates/hpa.yaml
+++ b/hello-world/templates/hpa.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if .Values.autoscaling.enabled -}}
+{{- if .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/hello-world/values.yaml
+++ b/hello-world/values.yaml
@@ -36,7 +36,16 @@ serviceAccount:
   create: true
   name: ""
 
-resources: {}
+# Requests are required for the HPA's targetCPUUtilizationPercentage to be
+# computable - without a cpu request, the HPA can't calculate utilization
+# and reports ScalingActive: False (FailedGetResourceMetric).
+resources:
+  requests:
+    cpu: 10m
+    memory: 16Mi
+  limits:
+    cpu: 100m
+    memory: 64Mi
 
 # Cloudflared tunnel configuration
 # Set enabled: true when you have the cloudflared-credentials secret
@@ -47,6 +56,13 @@ cloudflared:
     repository: cloudflare/cloudflared
     tag: latest
   secretName: cloudflared-credentials
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
## Summary
- `hello-world`'s ArgoCD Application showed `Health: Degraded`. Root cause: the HorizontalPodAutoscaler targets `cpu` utilization, but the chart's `values.yaml` exposed a `resources` value that the deployment template never actually consumed - so the `hello-world` container had no CPU request. The HPA reports `ScalingActive: False` (`FailedGetResourceMetric`, "missing request for cpu in container hello-world") when it can't compute a ratio, and ArgoCD's built-in HPA health check treats that exact condition as Degraded, which propagates to the whole Application.
- Wired `.Values.resources` into the main container and added `.Values.cloudflared.resources` for the optional sidecar, with small sane defaults (this is a lightweight echoserver test app).
- Also fixed an unrelated but adjacent bug in `templates/hpa.yaml`: a trailing `-}}` whitespace trim on the `{{- if .Values.autoscaling.enabled -}}` line merged the leading `---` document separator into the same line as `apiVersion:`, which broke `helm lint` / `helm template --validate` (didn't block ArgoCD's own rendering, but is a real lint failure).
- Bumped chart version 0.1.0 -> 0.1.1 per this repo's versioning convention.

## Test plan
- [x] `helm lint ./hello-world` passes (was failing before this PR)
- [x] `helm template hello-world ./hello-world` and `--set cloudflared.enabled=true` both render `resources:` correctly on the relevant container(s)
- [ ] After ArgoCD syncs (Application targetRevision: main), confirm `kubectl -n hello-world get hpa hello-world` shows `cpu: <n>%/80%` instead of `<unknown>/80%`
- [ ] Confirm the `hello-world` ArgoCD Application's health flips from `Degraded` back to `Healthy`